### PR TITLE
Add map view permissions

### DIFF
--- a/target/tests/tests_views.py
+++ b/target/tests/tests_views.py
@@ -43,7 +43,13 @@ class TargetTests(TestCase):
             location=Point(-54.100002, -33.900002)
         )
 
+    def test_get_map_page_user_not_logged(self):
+        url = reverse('target_map')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+
     def test_get_map_page_ok(self):
+        self.client.force_login(self.test_active_user)
         url = reverse('target_map')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/target/views.py
+++ b/target/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
@@ -5,6 +6,7 @@ from .serializers import TargetSerializer, TopicSerializer
 from .models import Target, Topic
 
 
+@login_required(login_url='rest_login')
 def target_map(request):
     return render(request, 'target/map.html')
 


### PR DESCRIPTION
Now, the user must be logged in to see the targets in the map. 