### PR TITLE
Add limit for maximum of targets per user

### DIFF
--- a/base/settings/base.py
+++ b/base/settings/base.py
@@ -21,7 +21,6 @@ load_dotenv(dotenv_path=env_path)
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
@@ -150,7 +149,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
 
@@ -164,7 +162,6 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 
@@ -173,3 +170,7 @@ STATIC_URL = '/static/'
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 MEDIA_URL = '/media/'
+
+# Project variables
+
+MAX_NUMBER_OF_TARGETS = 10

--- a/target/serializers.py
+++ b/target/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from .models import Target, Topic
@@ -10,9 +11,19 @@ class TargetSerializer(GeoFeatureModelSerializer):
         read_only_fields = ['user']
         geo_field = 'location'
 
+    def check_max_num_of_targets(self, user):
+        num_current_targets = Target.objects.filter(user=user).count()
+        if num_current_targets >= settings.MAX_NUMBER_OF_TARGETS:
+            msg = f"It is not possible to create more than {settings.MAX_NUMBER_OF_TARGETS} targets."
+            raise serializers.ValidationError(msg)
+
     def create(self, validated_data):
         request = self.context.get('request')
         validated_data['user'] = request.user
+
+        if not request.user.is_superuser:
+            self.check_max_num_of_targets(request.user)
+
         return super(TargetSerializer, self).create(validated_data)
 
 

--- a/target/serializers.py
+++ b/target/serializers.py
@@ -12,7 +12,7 @@ class TargetSerializer(GeoFeatureModelSerializer):
         geo_field = 'location'
 
     def check_max_num_of_targets(self, user):
-        num_current_targets = Target.objects.filter(user=user).count()
+        num_current_targets = user.target_set.count()
         if num_current_targets >= settings.MAX_NUMBER_OF_TARGETS:
             msg = f"It is not possible to create more than {settings.MAX_NUMBER_OF_TARGETS} targets."
             raise serializers.ValidationError(msg)

--- a/target/tests/tests_views.py
+++ b/target/tests/tests_views.py
@@ -58,8 +58,8 @@ class TargetTests(TestCase):
         self.assertEqual(response.data.get('properties').get('user'), self.test_active_user.id)
 
     def test_create_more_targets_than_it_is_allowed(self):
-        initial_num_of_targets = Target.objects.filter(user=self.test_active_user).count()
-        for i in range(0, (settings.MAX_NUMBER_OF_TARGETS-initial_num_of_targets)):
+        initial_num_of_targets = self.test_active_user.target_set.count()
+        for i in range(0, (settings.MAX_NUMBER_OF_TARGETS - initial_num_of_targets)):
             TargetFactory(user=self.test_active_user)
 
         self.client.force_login(self.test_active_user)

--- a/target/tests/tests_views.py
+++ b/target/tests/tests_views.py
@@ -71,7 +71,7 @@ class TargetTests(TestCase):
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertLessEqual(Target.objects.filter(user=self.test_active_user).count(), settings.MAX_NUMBER_OF_TARGETS)
+        self.assertLessEqual(self.test_active_user.target_set.count(), settings.MAX_NUMBER_OF_TARGETS)
 
     def test_get_target_list_as_admin(self):
         self.client.force_login(self.test_superuser)

--- a/target/tests/tests_views.py
+++ b/target/tests/tests_views.py
@@ -3,6 +3,7 @@ from PIL import Image
 
 from django.test import TestCase
 from django.urls import reverse
+from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -55,6 +56,22 @@ class TargetTests(TestCase):
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data.get('properties').get('user'), self.test_active_user.id)
+
+    def test_create_more_targets_than_it_is_allowed(self):
+        initial_num_of_targets = Target.objects.filter(user=self.test_active_user).count()
+        for i in range(0, (settings.MAX_NUMBER_OF_TARGETS-initial_num_of_targets)):
+            TargetFactory(user=self.test_active_user)
+
+        self.client.force_login(self.test_active_user)
+        url = reverse("target-list")
+        data = {
+            "title": "Point",
+            "radius": 45000,
+            "location": "POINT (-42.796763 -5.077056)"
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertLessEqual(Target.objects.filter(user=self.test_active_user).count(), settings.MAX_NUMBER_OF_TARGETS)
 
     def test_get_target_list_as_admin(self):
         self.client.force_login(self.test_superuser)


### PR DESCRIPTION
Common users just can add as many targets as it is defined in the project settings.